### PR TITLE
fix

### DIFF
--- a/src/JaravelServiceProvider.php
+++ b/src/JaravelServiceProvider.php
@@ -93,7 +93,6 @@ class JaravelServiceProvider extends ServiceProvider
                     "reporting_host" => ConfigRepository::get('jaravel.agent_host', '127.0.0.1'),
                     "reporting_port" => ConfigRepository::get('jaravel.agent_port', 6832),
                 ],
-                'trace_id_header' => ConfigRepository::get('jaravel.trace_id_header', 'x-trace-id'),
                 'dispatch_mode' => Config::JAEGER_OVER_BINARY_UDP,
             ],
             ConfigRepository::get('jaravel.tracer_name', 'application')

--- a/src/Services/Span/SpanCreator.php
+++ b/src/Services/Span/SpanCreator.php
@@ -8,7 +8,7 @@ use OpenTracing\Formats;
 use OpenTracing\Reference;
 use OpenTracing\Span;
 use OpenTracing\Tracer;
-use Illuminate\Support\Facades\Config;
+use const Jaeger\TRACE_ID_HEADER;
 
 class SpanCreator
 {
@@ -38,7 +38,7 @@ class SpanCreator
         }
 
         $spanContext = $this->tracer
-            ->extract(Formats\TEXT_MAP, [Config::get('jaravel.trace_id_header', 'x-trace-id') => $traceIdHeader]);
+            ->extract(Formats\TEXT_MAP, [TRACE_ID_HEADER => $traceIdHeader]);
 
         return array_merge(
             $baseOptions,

--- a/src/Services/TraceIdHeaderRetriever.php
+++ b/src/Services/TraceIdHeaderRetriever.php
@@ -2,22 +2,20 @@
 
 namespace Umbrellio\Jaravel\Services;
 
-use Illuminate\Support\Facades\Config;
+use const Jaeger\TRACE_ID_HEADER;
 
 class TraceIdHeaderRetriever
 {
     public function retrieve(array $carrier = []): ?string
     {
-        $headerName = strtolower(Config::get('jaravel.trace_id_header', 'x-trace-id'));
-
-        if (empty($carrier[$headerName])) {
+        if (empty($carrier[TRACE_ID_HEADER])) {
             return null;
         }
 
-        if (is_array($carrier[$headerName])) {
-            return $carrier[$headerName][0];
+        if (is_array($carrier[TRACE_ID_HEADER])) {
+            return $carrier[TRACE_ID_HEADER][0];
         }
 
-        return $carrier[$headerName];
+        return $carrier[TRACE_ID_HEADER];
     }
 }

--- a/tests/JaravelTestCase.php
+++ b/tests/JaravelTestCase.php
@@ -39,14 +39,12 @@ abstract class JaravelTestCase extends TestCase
 
     private function jaravelConfiguration(): array
     {
-        $traceHeaderName = 'x-trace-id';
-
         return [
             'enabled' => true,
             'tracer_name' => 'application',
             'agent_host' => '127.0.0.1',
             'agent_port' => 6831,
-            'trace_id_header' => $traceHeaderName,
+            'trace_id_header' => 'X-Trace-Id',
             'logs_enabled' => true,
 
             'custom_tracer_callable' => fn () => new Tracer(
@@ -55,8 +53,7 @@ abstract class JaravelTestCase extends TestCase
                 new ConstSampler(),
                 true,
                 null,
-                new ScopeManager(),
-                $traceHeaderName
+                new ScopeManager()
             ),
 
             'http' => [


### PR DESCRIPTION
Фикс для рабочей совместимости версий 1 и 2. Была ошибка что X-Trace-Id проставлялся как имя заголовка, через который должен передаваться спан контекст. На самом деле обе либки используют заголовок 'uber-trace-id', менять который не нужно. X-Trace-Id пользовательский заголовок в response.